### PR TITLE
[TRIVIAL] Fix testnet docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository contains a Docker Compose setup for running a PostgreSQL databas
 
 ### 2. External Node
 
-- **Image:** `matterlabs/external-node:2.0-v26.7.0`
+- **Image:** `matterlabs/external-node:v28.2.1`
 - **Depends on:** PostgreSQL service (ensures the service starts after PostgreSQL is healthy)
 - **Ports:**
   - `3060` (HTTP)

--- a/testnet-external-node.yml
+++ b/testnet-external-node.yml
@@ -32,7 +32,7 @@ services:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430
   external-node:
-    image: "matterlabs/external-node:28.2.1"
+    image: "matterlabs/external-node:v28.2.1"
     command: ["--components=all,da_fetcher"]
     depends_on:
       postgres:


### PR DESCRIPTION
- The testnode Docker image is missing the `v` prefix, which makes Docker unable to fetch the image.
- Also, updated the readme with the corresponding version.